### PR TITLE
CLI-21-Validate-Binary-Search-Tree

### DIFF
--- a/11. DepthFirstSearch/leetcode98.py
+++ b/11. DepthFirstSearch/leetcode98.py
@@ -1,0 +1,71 @@
+'''
+98. Validate Binary Search Tree
+Medium
+
+Topics
+Companies
+Given the root of a binary tree, determine if it is a valid binary search tree
+(BST).
+
+A valid BST is defined as follows:
+
+The left 
+subtree
+ of a node contains only nodes with keys less than the node's key.
+The right subtree of a node contains only nodes with keys greater than the
+node's key.
+Both the left and right subtrees must also be binary search trees.
+ 
+
+Example 1:
+Input: root = [2,1,3]
+Output: true
+
+Example 2:
+Input: root = [5,1,4,null,null,3,6]
+Output: false
+Explanation: The root node's value is 5 but its right child's value is 4.
+ 
+
+Constraints:
+
+The number of nodes in the tree is in the range [1, 104].
+-231 <= Node.val <= 231 - 1
+'''
+class TreeNode:
+    def __init__(self, val=0, left=None, right=None):
+        self.val = val
+        self.left = left
+        self.right = right
+
+class Solution:
+    def is_valid_bst(self, root: TreeNode) -> bool:
+        def validate(node, low=-float('inf'), high=float('inf')):
+            # An empty tree is a valid BST
+            if not node:
+                return True
+            # The current node's value must be within the range [low, high]
+            if not (low < node.val < high):
+                return False
+            # Recursively validate the left and right subtrees
+            return (validate(node.left, low, node.val) and
+                    validate(node.right, node.val, high))
+        
+        return validate(root)
+
+# Example usage:
+# Constructing the tree [2, 1, 3]
+root1 = TreeNode(2)
+root1.left = TreeNode(1)
+root1.right = TreeNode(3)
+
+# Constructing the tree [5, 1, 4, None, None, 3, 6]
+root2 = TreeNode(5)
+root2.left = TreeNode(1)
+root2.right = TreeNode(4)
+root2.right.left = TreeNode(3)
+root2.right.right = TreeNode(6)
+
+sol = Solution()
+print('Result1 = ', sol.is_valid_bst(root1))  # Output: True
+print('Result2 = ', sol.is_valid_bst(root2))  # Output: False


### PR DESCRIPTION
To determine if a given binary tree is a valid binary search tree (BST), we need to ensure that every node in the tree adheres to the BST properties. Specifically, the left subtree of a node must contain only nodes with keys less than the node's key, and the right subtree must contain only nodes with keys greater than the node's key. Additionally, both left and right subtrees must also be valid BSTs.

Explanation:

1. TreeNode Class: This class is used to create nodes of the binary tree, with each node having a value (val), and pointers to left and right children (left and right).
2. is_valid_bst Function: This function checks if the binary tree rooted at root is a valid BST. It uses a helper function validate which takes a node and the range [low, high] that the node's value must be within.
3. validate Function:
- If the node is None, it returns True (an empty tree is a valid BST).
- If the node's value is not within the range [low, high], it returns False.
- It recursively validates the left subtree with an updated upper bound (node.val) and the right subtree with an updated lower bound (node.val).

4. Example Usage:

- The first example constructs a tree [2, 1, 3] and checks if it is a valid BST, which it is.
- The second example constructs a tree [5, 1, 4, None, None, 3, 6] and checks if it is a valid BST, which it is not because the right child of the root (4) has a left child (3) that is less than 5.