### PR TITLE
CLI-22-Kth-Smallest-Element-In-a-Bst

### DIFF
--- a/11. DepthFirstSearch/leetcode230.py
+++ b/11. DepthFirstSearch/leetcode230.py
@@ -1,0 +1,82 @@
+'''
+230. Kth Smallest Element in a BST
+Solved
+Medium
+
+Topics
+Companies
+
+Hint
+Given the root of a binary search tree, and an integer k, return the kth
+smallest value (1-indexed) of all the values of the nodes in the tree.
+
+Example 1:
+Input: root = [3,1,4,null,2], k = 1
+Output: 1
+
+Example 2:
+Input: root = [5,3,6,2,4,null,null,1], k = 3
+Output: 3
+ 
+Constraints:
+The number of nodes in the tree is n.
+1 <= k <= n <= 104
+0 <= Node.val <= 104
+ 
+Follow up: If the BST is modified often (i.e., we can do insert and delete
+operations) and you need to find the kth smallest frequently, how would you
+optimize?
+'''
+class TreeNode:
+    def __init__(self, val=0, left=None, right=None):
+        self.val = val
+        self.left = left
+        self.right = right
+
+class Solution:
+    def kth_smallest(self, root, k):
+        def count_nodes(node):
+            if not node:
+                return 0
+            return 1 + count_nodes(node.left) + count_nodes(node.right)
+
+        left_count = count_nodes(root.left)
+        
+        if k <= left_count:
+            return self.kth_smallest(root.left, k)
+        elif k == left_count + 1:
+            return root.val
+        else:
+            return self.kth_smallest(root.right, k - left_count - 1)
+
+# 插入函数，用于构建示例树
+def insert(root, val):
+    if root is None:
+        return TreeNode(val)
+    if val < root.val:
+        root.left = insert(root.left, val)
+    else:
+        root.right = insert(root.right, val)
+    return root
+
+# 示例用法:
+# 构建例子1的BST: root = [3,1,4,null,2], k = 1
+root1 = TreeNode(3)
+root1 = insert(root1, 1)
+root1 = insert(root1, 4)
+root1 = insert(root1, 2)
+
+sol = Solution()
+k1 = 1
+print('Result1 = ', sol.kth_smallest(root1, k1))  # 输出: 1
+
+# 构建例子2的BST: root = [5,3,6,2,4,null,null,1], k = 3
+root2 = TreeNode(5)
+root2 = insert(root2, 3)
+root2 = insert(root2, 6)
+root2 = insert(root2, 2)
+root2 = insert(root2, 4)
+root2 = insert(root2, 1)
+
+k2 = 3
+print('Result2 = ', sol.kth_smallest(root2, k2))  # 输出: 3

--- a/11. DepthFirstSearch/leetcode98.py
+++ b/11. DepthFirstSearch/leetcode98.py
@@ -9,9 +9,7 @@ Given the root of a binary tree, determine if it is a valid binary search tree
 
 A valid BST is defined as follows:
 
-The left 
-subtree
- of a node contains only nodes with keys less than the node's key.
+The left subtree of a node contains only nodes with keys less than the node's key.
 The right subtree of a node contains only nodes with keys greater than the
 node's key.
 Both the left and right subtrees must also be binary search trees.


### PR DESCRIPTION
To solve the problem of finding the kth smallest value in a Binary Search Tree (BST), we can use an in-order traversal. The in-order traversal of a BST visits nodes in ascending order of their values. Here's the step-by-step approach:

1. Perform an in-order traversal of the tree.
2. Keep track of the count of nodes visited.
3. When the count equals k, return the value of the current node.

If the BST is frequently modified (insertions and deletions), we can optimize the solution by maintaining the count of nodes in the left subtree for each node. This way, we can directly determine the position of the kth smallest element without performing a complete in-order traversal every time.

Here's how we can achieve this:
1. Augment each node in the BST to store the count of nodes in its left subtree.
2. Use this count to navigate to the kth smallest element efficiently.