### PR TITLE
CLI-36-Last-Stone-Weight

### DIFF
--- a/6. Heaps/leetcode1046.py
+++ b/6. Heaps/leetcode1046.py
@@ -1,0 +1,63 @@
+'''
+1046. Last Stone Weight
+Easy
+
+Topics
+Companies
+
+Hint
+You are given an array of integers stones where stones[i] is the weight of the
+ith stone.
+
+We are playing a game with the stones. On each turn, we choose the heaviest
+two stones and smash them together. Suppose the heaviest two stones have
+weights x and y with x <= y. The result of this smash is:
+
+If x == y, both stones are destroyed, and
+If x != y, the stone of weight x is destroyed, and the stone of weight y has
+new weight y - x.
+
+At the end of the game, there is at most one stone left.
+Return the weight of the last remaining stone. If there are no stones left, return 0.
+
+Example 1:
+Input: stones = [2,7,4,1,8,1]
+Output: 1
+Explanation: 
+We combine 7 and 8 to get 1 so the array converts to [2,4,1,1,1] then,
+we combine 2 and 4 to get 2 so the array converts to [2,1,1,1] then,
+we combine 2 and 1 to get 1 so the array converts to [1,1,1] then,
+we combine 1 and 1 to get 0 so the array converts to [1] then that's the value of the last stone.
+
+Example 2:
+Input: stones = [1]
+Output: 1
+ 
+Constraints:
+1 <= stones.length <= 30
+1 <= stones[i] <= 1000
+'''
+from typing import List
+import heapq
+
+class Solution:
+    def lastStoneWeight(self, stones: List[int]) -> int:
+        heap = [-stone for stone in stones]
+        heapq.heapify(heap)
+        
+        while len(heap) > 1:
+            # Pop the two largest stones
+            y = -heapq.heappop(heap)
+            x = -heapq.heappop(heap)
+            
+            if x != y:
+                # If x != y, push the difference back into the heap
+                heapq.heappush(heap, x - y)
+        
+        # If there are no stones left, return 0, otherwise return the last stone's weight
+        return -heapq.heappop(heap) if heap else 0
+    
+
+solution = Solution()
+stones = [2,7,4,1,8,1]
+print('Result1 = ', solution.lastStoneWeight(stones))


### PR DESCRIPTION
There are several issues with the given code, including indentation problems, incorrect method names, and logical errors. Let's address each problem step-by-step:

1. Indentation: Python requires consistent indentation. The provided code has inconsistent indentation, which needs to be fixed.
2. Method Names: The correct method names for the heapq module are heappush, heappop, and heapify, not heapq.pushpop or heapq.heaplify.
3. Logical Errors:
- You need to ensure that you are correctly checking if the heap is empty.
- The continue statement should be used within the loop.
- The else statement needs proper alignment.
- The final return statement has incorrect syntax.

Explanation
1. Negating Values for Max-Heap:
- Python's heapq module only provides a min-heap. To simulate a max-heap, we negate the values of the stones.
- This way, the largest stone will be the smallest negative number.

2. Heapify:
- heapq.heapify(heap) transforms the list into a heap in-place in linear time.

3. Main Loop:
- Continue popping the two largest stones until only one or none remains.
- If the two stones are not equal, the difference is pushed back into the heap.

4. Final Return:
- If the heap is not empty, return the last remaining stone (negated back to positive).
- If the heap is empty, return 0.