### PR TITLE
CLI-45-Rotting-Oranges

### DIFF
--- a/5. Graph/leetcode286.py
+++ b/5. Graph/leetcode286.py
@@ -46,7 +46,7 @@ rooms[i][j] is -1, 0, or 231 - 1.
 from collections import deque
 
 class Solution:
-    def wallsAndGates(self, rooms):
+    def wallsAndGatesBFS(self, rooms):
         if not rooms:
             return
         
@@ -73,6 +73,33 @@ class Solution:
                     rooms[nx][ny] = rooms[x][y] + 1
                     queue.append((nx, ny))
 
+
+    def wallsAndGatesDFS(self, rooms):
+        if not rooms:
+            return
+        
+        m, n = len(rooms), len(rooms[0])
+        
+        def dfs(x, y, distance):
+            # If out of bounds or if this room is not an empty room or already has a shorter distance
+            if x < 0 or x >= m or y < 0 or y >= n or rooms[x][y] < distance:
+                return
+            # Update the distance to this room
+            rooms[x][y] = distance
+            # Recursively update neighboring rooms
+            dfs(x + 1, y, distance + 1)
+            dfs(x - 1, y, distance + 1)
+            dfs(x, y + 1, distance + 1)
+            dfs(x, y - 1, distance + 1)
+        
+        # Start DFS from each gate (0)
+        for i in range(m):
+            for j in range(n):
+                if rooms[i][j] == 0:
+                    dfs(i, j, 0)
+
+
+
 # Example usage
 rooms1 = [
     [2147483647, -1, 0, 2147483647],
@@ -82,9 +109,16 @@ rooms1 = [
 ]
 
 solution = Solution()
-solution.wallsAndGates(rooms1)
-print(rooms1)  # Output should be the modified rooms grid with distances filled
+# solution.wallsAndGatesBFS(rooms1)
+# print(rooms1)  # Output should be the modified rooms grid with distances filled
+solution.wallsAndGatesDFS(rooms1)
+print(rooms1)
+
 
 rooms2 = [[-1]]
-solution.wallsAndGates(rooms2)
-print(rooms2)  # Output should be [[-1]]
+# solution.wallsAndGatesBFS(rooms2)
+# print(rooms2)  # Output should be [[-1]]
+solution.wallsAndGatesDFS(rooms2)
+print(rooms2)
+
+

--- a/5. Graph/leetcode994.py
+++ b/5. Graph/leetcode994.py
@@ -1,0 +1,133 @@
+'''
+994. Rotting Oranges
+Medium
+
+Topics
+Companies
+You are given an m x n grid where each cell can have one of three values:
+
+0 representing an empty cell,
+1 representing a fresh orange, or
+2 representing a rotten orange.
+
+Every minute, any fresh orange that is 4-directionally adjacent to a rotten
+orange becomes rotten.
+
+Return the minimum number of minutes that must elapse until no cell has a
+fresh orange. If this is impossible, return -1.
+
+Example 1:
+Input: grid = [[2,1,1],[1,1,0],[0,1,1]]
+Output: 4
+
+Example 2:
+Input: grid = [[2,1,1],[0,1,1],[1,0,1]]
+Output: -1
+Explanation: The orange in the bottom left corner (row 2, column 0) is never
+rotten, because rotting only happens 4-directionally.
+
+Example 3:
+Input: grid = [[0,2]]
+Output: 0
+Explanation: Since there are already no fresh oranges at minute 0, the answer
+is just 0.
+ 
+Constraints:
+m == grid.length
+n == grid[i].length
+1 <= m, n <= 10
+grid[i][j] is 0, 1, or 2.
+'''
+from collections import deque
+
+class Solution:
+    def orangesRottingDFS(self, grid):
+        if not grid:
+            return -1
+
+        rows, cols = len(grid), len(grid[0])
+        fresh_oranges = 0
+        max_minutes = 0
+
+        # Count fresh oranges and add rotten oranges to a list with their starting minute
+        rotten_oranges = []
+        for r in range(rows):
+            for c in range(cols):
+                if grid[r][c] == 1:
+                    fresh_oranges += 1
+                elif grid[r][c] == 2:
+                    rotten_oranges.append((r, c, 0))
+
+        # DFS function to rot adjacent fresh oranges
+        def dfs(x, y, minutes):
+            nonlocal max_minutes
+            max_minutes = max(max_minutes, minutes)
+            directions = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+
+            for dx, dy in directions:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < rows and 0 <= ny < cols and grid[nx][ny] == 1:
+                    grid[nx][ny] = 2
+                    dfs(nx, ny, minutes + 1)
+
+        # Apply DFS starting from all initially rotten oranges
+        for x, y, start_minutes in rotten_oranges:
+            dfs(x, y, start_minutes)
+
+        # Check if there are still fresh oranges left
+        for row in grid:
+            if 1 in row:
+                return -1
+
+        return max_minutes
+
+
+    def orangesRottingBFS(self, grid):
+        if not grid:
+            return -1
+        
+        rows, cols = len(grid), len(grid[0])
+        queue = deque()
+        fresh_oranges = 0
+        
+        # Initialize the queue with all rotten oranges and count the fresh oranges
+        for r in range(rows):
+            for c in range(cols):
+                if grid[r][c] == 2:
+                    queue.append((r, c))
+                elif grid[r][c] == 1:
+                    fresh_oranges += 1
+        
+        # If there are no fresh oranges, return 0 as no time is needed
+        if fresh_oranges == 0:
+            return 0
+        
+        minutes_passed = 0
+        directions = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        
+        # Perform BFS
+        while queue and fresh_oranges > 0:
+            minutes_passed += 1
+            for _ in range(len(queue)):
+                x, y = queue.popleft()
+                
+                for dx, dy in directions:
+                    nx, ny = x + dx, y + dy
+                    
+                    if 0 <= nx < rows and 0 <= ny < cols and grid[nx][ny] == 1:
+                        grid[nx][ny] = 2
+                        fresh_oranges -= 1
+                        queue.append((nx, ny))
+        
+        # If there are still fresh oranges left, return -1
+        return minutes_passed if fresh_oranges == 0 else -1
+    
+# Example usage
+grid = [
+    [2, 1, 1],
+    [1, 1, 0],
+    [0, 1, 1]
+]
+solution = Solution()
+# print(solution.orangesRottingDFS(grid))  # Output: 4
+print(solution.orangesRottingBFS(grid))  # Output: 4


### PR DESCRIPTION
To solve this problem, we can use a Breadth-First Search (BFS) approach. The idea is to start from all initially rotten oranges and spread the rot to adjacent fresh oranges minute by minute. Here are the steps for the solution:

1. Initialize the BFS Queue: Start by adding all the initially rotten oranges to a queue. We'll also keep track of the count of fresh oranges.
2. Perform BFS: Use BFS to traverse the grid. For each rotten orange, mark the adjacent fresh oranges as rotten and add them to the queue for the next level of BFS.
3. Track Time: Keep a counter to track the number of minutes that elapse as we spread the rot.
4. Check Completion: At the end, if there are still fresh oranges left, return -1. Otherwise, return the number of minutes elapsed.

Explanation:
1. Queue Initialization: We first initialize the queue with all the rotten oranges and count the number of fresh oranges.
2. BFS Process: We perform BFS where each iteration represents a minute passing. For each rotten orange, we check its four possible directions (up, down, left, right). If we find a fresh orange, we mark it as rotten and add it to the queue.
3. Time Tracking: We increase the minutes counter after processing each level of BFS.
4. Completion Check: After the BFS is complete, we check if there are any fresh oranges left. If there are, we return -1, otherwise, we return the time elapsed.