### PR TITLE
CLI-46-Pacific-Atlantic-Water-Flow

### DIFF
--- a/5. Graph/leetcode417.py
+++ b/5. Graph/leetcode417.py
@@ -1,0 +1,101 @@
+'''
+417. Pacific Atlantic Water Flow
+Medium
+
+Topics
+Companies
+There is an m x n rectangular island that borders both the Pacific Ocean and
+Atlantic Ocean. The Pacific Ocean touches the island's left and top edges, and
+the Atlantic Ocean touches the island's right and bottom edges.
+
+The island is partitioned into a grid of square cells. You are given an m x n
+integer matrix heights where heights[r][c] represents the height above sea
+level of the cell at coordinate (r, c).
+
+The island receives a lot of rain, and the rain water can flow to neighboring
+cells directly north, south, east, and west if the neighboring cell's height
+is less than or equal to the current cell's height. Water can flow from any
+cell adjacent to an ocean into the ocean.
+
+Return a 2D list of grid coordinates result where result[i] = [ri, ci] denotes
+that rain water can flow from cell (ri, ci) to both the Pacific and Atlantic
+oceans.
+
+Example 1:
+Input: heights = [[1,2,2,3,5],[3,2,3,4,4],[2,4,5,3,1],[6,7,1,4,5],[5,1,1,2,4]]
+Output: [[0,4],[1,3],[1,4],[2,2],[3,0],[3,1],[4,0]]
+Explanation: The following cells can flow to the Pacific and Atlantic oceans,
+as shown below:
+[0,4]: [0,4] -> Pacific Ocean 
+       [0,4] -> Atlantic Ocean
+[1,3]: [1,3] -> [0,3] -> Pacific Ocean 
+       [1,3] -> [1,4] -> Atlantic Ocean
+[1,4]: [1,4] -> [1,3] -> [0,3] -> Pacific Ocean 
+       [1,4] -> Atlantic Ocean
+[2,2]: [2,2] -> [1,2] -> [0,2] -> Pacific Ocean 
+       [2,2] -> [2,3] -> [2,4] -> Atlantic Ocean
+[3,0]: [3,0] -> Pacific Ocean 
+       [3,0] -> [4,0] -> Atlantic Ocean
+[3,1]: [3,1] -> [3,0] -> Pacific Ocean 
+       [3,1] -> [4,1] -> Atlantic Ocean
+[4,0]: [4,0] -> Pacific Ocean 
+       [4,0] -> Atlantic Ocean
+Note that there are other possible paths for these cells to flow to the
+Pacific and Atlantic oceans.
+
+Example 2:
+Input: heights = [[1]]
+Output: [[0,0]]
+Explanation: The water can flow from the only cell to the Pacific and Atlantic
+oceans.
+ 
+Constraints:
+m == heights.length
+n == heights[r].length
+1 <= m, n <= 200
+0 <= heights[r][c] <= 105
+'''
+class Solution:
+    def pacificAtlantic(self, heights):
+        if not heights or not heights[0]:
+            return []
+
+        m, n = len(heights), len(heights[0])
+
+        def dfs(matrix, reachable, x, y):
+            reachable[x][y] = True
+            for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < m and 0 <= ny < n and not reachable[nx][ny] and \
+                     heights[nx][ny] >= heights[x][y]:
+                    dfs(matrix, reachable, nx, ny)
+
+        pacific_reachable = [[False for _ in range(n)] for _ in range(m)]
+        atlantic_reachable = [[False for _ in range(n)] for _ in range(m)]
+
+        for i in range(m):
+            dfs(heights, pacific_reachable, i, 0)
+            dfs(heights, atlantic_reachable, i, n - 1)
+
+        for j in range(n):
+            dfs(heights, pacific_reachable, 0, j)
+            dfs(heights, atlantic_reachable, m - 1, j)
+
+        result = []
+        for i in range(m):
+            for j in range(n):
+                if pacific_reachable[i][j] and atlantic_reachable[i][j]:
+                    result.append([i, j])
+
+        return result
+
+# 示例用法
+heights = [
+    [1, 2, 2, 3, 5],
+    [3, 2, 3, 4, 4],
+    [2, 4, 5, 3, 1],
+    [6, 7, 1, 4, 5],
+    [5, 1, 1, 2, 4]
+]
+solution = Solution()
+print(solution.pacificAtlantic(heights))  # Output: [[0, 4], [1, 3], [1, 4], [2, 2], [3, 0], [3, 1], [4, 0]]


### PR DESCRIPTION
To solve the problem of determining which cells in the grid can allow water to flow to both the Pacific and Atlantic oceans, we can use a Depth-First Search (DFS) or Breadth-First Search (BFS) approach. Given the constraints, DFS is a suitable choice due to its simplicity in handling grid traversal.

Here's the plan:
1. Initialization: Create two matrices, pacific_reachable and atlantic_reachable, to keep track of cells that can reach the Pacific and Atlantic oceans, respectively.
2. Boundary Cells: Perform DFS from all cells adjacent to the Pacific (top and left edges) and mark cells reachable from these edges. Do the same for the Atlantic (bottom and right edges).
3. DFS Function: Define a helper function for DFS that marks reachable cells based on the current cell's height and ensures we only move to cells with height equal to or greater than the current cell.
4. Result Compilation: After performing DFS from all boundary cells, intersect the results from pacific_reachable and atlantic_reachable to find cells that can reach both oceans.

Explanation:
- DFS Traversal: The dfs function recursively marks cells that can be reached from the current cell, moving only to cells with heights greater than or equal to the current cell.
- Matrix Initialization: pacific_reachable and atlantic_reachable matrices are used to track reachability for each ocean.
- Boundary Cells Processing: We initiate DFS from the boundary cells for both oceans and mark reachable cells.
- Result Compilation: The final result is compiled by checking which cells are marked as reachable in both pacific_reachable and atlantic_reachable.