### PR TITLE
CLI-48-Course-Schedule

### DIFF
--- a/5. Graph/leetcode207.py
+++ b/5. Graph/leetcode207.py
@@ -1,0 +1,84 @@
+'''
+207. Course Schedule
+Medium
+
+Topics
+Companies
+
+Hint
+There are a total of numCourses courses you have to take, labeled from 0 to
+numCourses - 1. You are given an array prerequisites where prerequisites[i] = 
+[ai, bi] indicates that you must take course bi first if you want to take
+course ai.
+
+For example, the pair [0, 1], indicates that to take course 0 you have to
+first take course 1.
+Return true if you can finish all courses. Otherwise, return false.
+
+Example 1:
+Input: numCourses = 2, prerequisites = [[1,0]]
+Output: true
+Explanation: There are a total of 2 courses to take. 
+To take course 1 you should have finished course 0. So it is possible.
+
+Example 2:
+Input: numCourses = 2, prerequisites = [[1,0],[0,1]]
+Output: false
+Explanation: There are a total of 2 courses to take. 
+To take course 1 you should have finished course 0, and to take course 0 you
+should also have finished course 1. So it is impossible.
+ 
+Constraints:
+1 <= numCourses <= 2000
+0 <= prerequisites.length <= 5000
+prerequisites[i].length == 2
+0 <= ai, bi < numCourses
+All the pairs prerequisites[i] are unique.
+'''
+from collections import defaultdict
+from typing import List
+
+class Solution:
+    def canFinish(self, numCourses: int, prerequisites: List[List[int]]) -> bool:
+        # 構建鄰接表
+        graph = defaultdict(list)
+        for dest, src in prerequisites:
+            graph[src].append(dest)
+        
+        # 狀態：0 = 未訪問, 1 = 訪問中, 2 = 已訪問
+        visited = [0] * numCourses
+        
+        def dfs(course):
+            if visited[course] == 1:
+                return False  # 發現環
+            if visited[course] == 2:
+                return True   # 已經檢查過這門課
+            
+            # 標記為訪問中
+            visited[course] = 1
+            
+            # 訪問所有依賴這門課的課程
+            for neighbor in graph[course]:
+                if not dfs(neighbor):
+                    return False
+            
+            # 標記為已訪問
+            visited[course] = 2
+            return True
+        
+        # 檢查所有課程
+        for course in range(numCourses):
+            if not dfs(course):
+                return False
+        
+        return True
+    
+numCourses = 2
+prerequisites = [[1,0]]
+
+solution = Solution()
+print('Result1 = ', solution.canFinish(numCourses, prerequisites))
+
+numCourses = 2
+prerequisites = [[1,0], [0, 1]]
+print('Result2 = ', solution.canFinish(numCourses, prerequisites))


### PR DESCRIPTION
問題描述
你有 numCourses 門課程要修，課程編號從 0 到 numCourses - 1。給你一個列表 prerequisites，其中 prerequisites[i] = [ai, bi] 表示要修課程 ai，你必須先修課程 bi。

例如：

[0, 1] 表示要修課程 0，你必須先修課程 1。
目標是判斷是否可以修完所有課程。如果可以，返回 True，否則返回 False。

解決思路
這個問題可以轉換為圖論中的「檢測有向圖中的環」問題。課程可以看作圖中的節點，先修課程的要求可以看作有向邊。如果圖中存在環，那麼就無法完成所有課程。

解決方案

我們可以使用深度優先搜索（DFS）來檢測圖中的環。具體步驟如下：
 
1. 構建圖：用鄰接表表示圖。每個課程是圖中的一個節點，先修課程的關係是有向邊。
 
2. 檢測環：使用 DFS 來檢測圖中的環。我們需要一個 visited 列表來追蹤每個節點的狀態：
0：未訪問
1：正在訪問中（DFS 進行中）
2：已訪問完畢

3. DFS 過程：
- 如果在訪問一個節點時，發現它已經在訪問中（狀態 1），說明圖中存在環。
- 如果節點已經訪問完畢（狀態 2），可以跳過。
- 訪問過程中標記節點為正在訪問中（1），訪問完畢後標記為已訪問（2）。