### PR TITLE
CLI-52-Redundant-Connection

### DIFF
--- a/5. Graph/leetcode684.py
+++ b/5. Graph/leetcode684.py
@@ -1,0 +1,83 @@
+'''
+684. Redundant Connection
+Medium
+
+Topics
+Companies
+In this problem, a tree is an undirected graph that is connected and has no
+cycles.
+You are given a graph that started as a tree with n nodes labeled from 1 to n,
+with one additional edge added. The added edge has two different vertices
+chosen from 1 to n, and was not an edge that already existed. The graph is
+represented as an array edges of length n where edges[i] = [ai, bi] indicates
+that there is an edge between nodes ai and bi in the graph.
+
+Return an edge that can be removed so that the resulting graph is a tree of n
+nodes. If there are multiple answers, return the answer that occurs last in
+the input.
+
+Example 1:
+Input: edges = [[1,2],[1,3],[2,3]]
+Output: [2,3]
+
+Example 2:
+Input: edges = [[1,2],[2,3],[3,4],[1,4],[1,5]]
+Output: [1,4]
+ 
+
+Constraints:
+n == edges.length
+3 <= n <= 1000
+edges[i].length == 2
+1 <= ai < bi <= edges.length
+ai != bi
+There are no repeated edges.
+The given graph is connected.
+'''
+from typing import List
+
+
+class UnionFind:
+    def __init__(self, size):
+        self.parent = list(range(size))
+        self.rank = [1] * size
+
+    def find(self, u):
+        if u != self.parent[u]:
+            self.parent[u] = self.find(self.parent[u])  # 路径压缩
+        return self.parent[u]
+
+    def union(self, u, v):
+        root_u = self.find(u)
+        root_v = self.find(v)
+        
+        if root_u == root_v:
+            return False  # u 和 v 已经在同一集合中，形成一个环
+        
+        if self.rank[root_u] > self.rank[root_v]:
+            self.parent[root_v] = root_u
+        elif self.rank[root_u] < self.rank[root_v]:
+            self.parent[root_u] = root_v
+        else:
+            self.parent[root_v] = root_u
+            self.rank[root_u] += 1
+            
+        return True  # u 和 v 成功合并
+
+
+class Solution:
+    def findRedundantConnection(self, edges: List[List[int]]) -> List[int]:
+        n = len(edges)
+        uf = UnionFind(n + 1)  # Union-Find 使用1基索引
+        
+        for u, v in edges:
+            if not uf.union(u, v):
+                return [u, v]
+            
+
+edges1 = [[1, 2], [1, 3], [2, 3]]
+solution = Solution()
+print(solution.findRedundantConnection(edges1))  # 输出: [2, 3]
+
+edges2 = [[1, 2], [2, 3], [3, 4], [1, 4], [1, 5]]
+print(solution.findRedundantConnection(edges2))  # 输出: [1, 4]


### PR DESCRIPTION
The Union-Find structure is particularly useful for tracking the connected components in a graph and can help in detecting cycles efficiently.

Here's a step-by-step approach to solve the problem:

1. Initialize Union-Find Structure:
- We create a Union-Find data structure to keep track of which nodes are in which components.

2. Process Each Edge:
- For each edge in the list, use the Union-Find structure to check if the two nodes of the edge are already connected.
- If they are connected, adding this edge would form a cycle. Hence, this is the redundant edge we are looking for.
- If they are not connected, union the two nodes.

3. Return the Redundant Edge:
- Since we need to return the edge that occurs last in the input, we continue processing until the end, and the last edge that forms a cycle is returned.

解释:
1. UnionFind 类: 提供了 union 和 find 操作。find 操作使用路径压缩来平坦化结构，确保未来查询更快。union 操作使用按秩合并来保持树的浅度。

3. Solution 类: findRedundantConnection 方法初始化 Union-Find 结构，并处理输入列表中的每一条边。如果 union 操作返回 False，则说明该边形成了环，我们返回该边。

