### PR TITLE
CLI-68-Merge-Intervals

### DIFF
--- a/20. Intervals/leetcode56.py
+++ b/20. Intervals/leetcode56.py
@@ -1,0 +1,86 @@
+'''
+56. Merge Intervals
+Classic!
+
+Medium
+
+Topics
+Companies
+Given an array of intervals where intervals[i] = [starti, endi], merge all
+overlapping intervals, and return an array of the non-overlapping intervals
+that cover all the intervals in the input.
+
+Example 1:
+Input: intervals = [[1,3],[2,6],[8,10],[15,18]]
+Output: [[1,6],[8,10],[15,18]]
+Explanation: Since intervals [1,3] and [2,6] overlap, merge them into [1,6].
+
+Example 2:
+Input: intervals = [[1,4],[4,5]]
+Output: [[1,5]]
+Explanation: Intervals [1,4] and [4,5] are considered overlapping.
+ 
+
+Constraints:
+1 <= intervals.length <= 104
+intervals[i].length == 2
+0 <= starti <= endi <= 104
+'''
+from typing import List
+
+
+class Solution:
+    # def merge1(self, intervals: List[List[int]]) -> List[List[int]]:
+    #     n = len(intervals)
+    #     i = 0
+    #     result = []
+    #     prev = intervals[0]
+    #     curr = intervals[1]
+
+    #     while i < n and curr[0] > prev[1]:
+    #         result.append(curr)
+    #         i += 1
+    #         prev = curr
+    #         curr = intervals[i]
+
+    #     prev = intervals[0]
+    #     curr = intervals[1]
+    #     while i < n and curr[1] <= prev[0]:
+    #         curr[0] = min(curr[0], intervals[i][0])
+    #         curr[1] = max(curr[1], intervals[i][1])
+    #         i += 1
+    #         prev = curr
+    #         curr = intervals[i]
+
+    #     while i < n:
+    #         result.append(intervals[i])
+    #         i += 1
+
+        # return result
+    
+    def merge(self, intervals: List[List[int]]) -> List[List[int]]:
+        # Step 1: Sort the intervals based on the start time
+        intervals.sort(key=lambda x: x[0])
+        
+        # Step 2: Initialize a list to hold merged intervals
+        merged = []
+        
+        for interval in intervals:
+            # If the merged list is empty or if the current interval does not overlap with the previous, append it
+            if not merged or merged[-1][1] < interval[0]:
+                merged.append(interval)
+            else:
+                # If it does overlap, merge the current interval with the previous one
+                merged[-1][1] = max(merged[-1][1], interval[1])
+        
+        return merged
+    
+
+solution =Solution()
+intervals = [[1,3],[2,6],[8,10],[15,18]]
+# print('Result1 = ', solution.merge(intervals))
+print('Result1 = ', solution.merge(intervals))
+
+intervals = [[1,4],[4,5]]
+print('Result2 = ', solution.merge(intervals))
+


### PR DESCRIPTION
To solve the problem of merging overlapping intervals, we'll follow these steps:

1. Sort the Intervals: First, we need to sort the intervals based on their start times. This will help us to merge overlapping intervals more easily.
2. Merge Intervals: We iterate through the sorted intervals and merge them if they overlap. If the current interval does not overlap with the previous interval, we add the previous interval to the result list and move to the next interval.
Here is a step-by-step breakdown of the approach:

1. Sorting: Sort the intervals based on the start time.

2. Merging:
- Initialize an empty list to hold the merged intervals.

3. Iterate through each interval:
- If the list of merged intervals is empty or if the current interval does not overlap with the previous one (i.e., the start time of the current interval is greater than the end time of the previous interval), append the current interval to the list.
- If the current interval overlaps with the previous one, merge them by updating the end time of the previous interval to the maximum end time of both intervals.

作用
intervals.sort(key=lambda x: x[0]) 將會根據每個區間的起始值進行排序。排序後，區間列表會按照區間的起始值從小到大排列。
詳細解釋
sort() 方法:
sort() 是 Python 中列表的內建方法，用於原地排序列表。這意味著排序會直接修改原始列表，而不是返回一個新的排序列表。
key 參數:
key 參數用來指定一個函數，該函數會應用到列表中的每個元素上，並返回一個值，這個值將用於排序的比較。
lambda x: x[0]:
lambda 是一個匿名函數（即沒有名稱的簡單函數）。
x 是列表中的一個元素，在這個情況下，每個元素都是一個區間（例如 [1, 3]）。
x[0] 表示區間的起始值。所以這個 lambda 函數會返回區間的起始值，用於排序。
使用範例
假設我們有一個區間列表 intervals，例如 [[1, 3], [2, 6], [8, 10], [15, 18]]。應用 intervals.sort(key=lambda x: x[0]) 後，排序過程如下：
python
Copy code
intervals = [[1, 3], [2, 6], [8, 10], [15, 18]]
intervals.sort(key=lambda x: x[0])
print(intervals)  # 輸出: [[1, 3], [2, 6], [8, 10], [15, 18]]

在這個例子中，原列表已經按照區間的起始值排序，因此排序不會改變列表的順序。如果我們有另一個未排序的列表：
python
Copy code
intervals = [[8, 10], [1, 3], [15, 18], [2, 6]]
intervals.sort(key=lambda x: x[0])
print(intervals)  # 輸出: [[1, 3], [2, 6], [8, 10], [15, 18]]

這段程式碼會根據每個區間的起始值對列表進行排序，結果是 [[1, 3], [2, 6], [8, 10], [15, 18]]。
為什麼排序很重要？
在合併區間問題中，排序是非常重要的步驟。通過排序，我們可以確保所有區間按照起始值的順序排列，這樣在遍歷和合併區間時，可以很方便地處理重疊的區間。這樣做能夠有效地合併所有重疊的區間並得到正確的結果。

理解 merged[-1]
在 Python 中，-1 是一個特殊的索引，表示列表中的最後一個元素。例如，如果有一個列表 merged，那麼 merged[-1] 就表示該列表的最後一個元素。

merged[-1][1] 的作用
假設 merged 是一個已經排序並正在合併的區間列表。merged[-1][1] 表示 merged 列表中最後一個區間的結束值。這用於檢查當前正在處理的區間是否與最後一個合併區間重疊，或者是否需要更新最後一個合併區間的結束值。

初始情況
在迭代區間列表時，我們首先檢查 merged 列表是否為空。如果為空，則直接將當前區間加入 merged 列表。當 merged 列表非空時，我們才會使用 merged[-1][1] 來訪問和操作最後一個區間的結束值。