### PR TITLE
CLI-70-Meeting-Rooms

### DIFF
--- a/20. Intervals/leetcode252.py
+++ b/20. Intervals/leetcode252.py
@@ -1,0 +1,46 @@
+'''
+252. Meeting Schedule
+Easy
+Given an array of meeting time interval objects consisting of start and end
+times [[start_1,end_1],[start_2,end_2],...] (start_i < end_i), determine if a
+person could add all meetings to their schedule without any conflicts.
+
+Example 1:
+Input: intervals = [(0,30),(5,10),(15,20)]
+Output: false
+Explanation:
+(0,30) and (5,10) will conflict
+(0,30) and (15,20) will conflict
+
+Example 2:
+Input: intervals = [(5,8),(9,15)]
+Output: true
+Note:
+(0,8),(8,10) is not considered a conflict at 8
+
+Constraints:
+0 <= intervals.length <= 500
+0 <= intervals[i].start < intervals[i].end <= 1,000,000
+'''
+class Solution:
+    def can_attend_all_meetings(self, intervals):
+        # Step 1: Sort the intervals by start times
+        intervals.sort(key=lambda x: x[0])
+        
+        # Step 2: Check for overlaps
+        for i in range(1, len(intervals)):
+            if intervals[i][0] < intervals[i-1][1]:
+                return False
+        
+        return True
+
+# Example usage:
+solution = Solution()
+
+# Example 1
+intervals1 = [(0, 30), (5, 10), (15, 20)]
+print(solution.can_attend_all_meetings(intervals1))  # Output: False
+
+# Example 2
+intervals2 = [(5, 8), (9, 15)]
+print(solution.can_attend_all_meetings(intervals2))  # Output: True


### PR DESCRIPTION
To determine if a person could add all meetings to their schedule without any conflicts, we need to check if any of the given meeting intervals overlap.

Here’s the plan:

1. Sort the intervals by their start times. This allows us to easily check for overlaps by comparing each interval with the one immediately before it.
2. Check for overlaps. Iterate through the sorted list and check if the start time of the current interval is less than the end time of the previous interval. If it is, there's a conflict.

排序会议时间间隔的方法有多种，可以根据开始时间或结束时间排序。以下是选择根据开始时间排序的原因及其解释。

选择根据开始时间排序的原因
直观简单：对于大多数时间间隔问题，根据开始时间排序是直观且简单的。排序后，我们只需要检查每个间隔的开始时间是否在前一个间隔的结束时间之前即可判断是否有重叠。
检查重叠：排序后，我们只需比较当前间隔的开始时间与前一个间隔的结束时间来判断重叠情况。这一步检查只需要一次遍历即可完成，效率较高。
根据结束时间排序的替代方法
虽然可以选择根据结束时间进行排序，但在这种情况下，它不会提供明显的优势，因为我们仍然需要遍历所有间隔并比较相邻间隔的开始时间和结束时间。