### PR TITLE
CLI-71-Meeting-Rooms-II

### DIFF
--- a/20. Intervals/leetcode252.py
+++ b/20. Intervals/leetcode252.py
@@ -34,13 +34,25 @@ class Solution:
         
         return True
 
+    def can_attend_all_meetings1(self, intervals):
+        # Step 1: Sort the intervals by start times
+        intervals.sort(key=lambda x: x[0])
+        end = intervals[0][1]
+        # Step 2: Check for overlaps
+        for i in range(1, len(intervals)):
+            if intervals[i][0] < end:
+                return False
+            else:
+                end = intervals[i][1]
+        
+        return True
 # Example usage:
 solution = Solution()
 
 # Example 1
 intervals1 = [(0, 30), (5, 10), (15, 20)]
-print(solution.can_attend_all_meetings(intervals1))  # Output: False
+print(solution.can_attend_all_meetings1(intervals1))  # Output: False
 
 # Example 2
 intervals2 = [(5, 8), (9, 15)]
-print(solution.can_attend_all_meetings(intervals2))  # Output: True
+print(solution.can_attend_all_meetings1(intervals2))  # Output: True

--- a/20. Intervals/leetcode253.py
+++ b/20. Intervals/leetcode253.py
@@ -1,0 +1,87 @@
+'''
+253. Meeting Schedule II
+
+Classic Greedy algorithm!
+
+Given an array of meeting time interval objects consisting of start and end
+times [[start_1,end_1],[start_2,end_2],...] (start_i < end_i), find the
+minimum number of days required to schedule all meetings without any conflicts
+.
+
+Example 1:
+
+Input: intervals = [(0,40),(5,10),(15,20)]
+Output: 2
+Explanation:
+day1: (0,40)
+day2: (5,10),(15,20)
+
+Example 2:
+Input: intervals = [(4,9)]
+Output: 1
+Note:
+(0,8),(8,10) is not considered a conflict at 8
+
+Constraints:
+0 <= intervals.length <= 500
+0 <= intervals[i].start < intervals[i].end <= 1,000,000
+'''
+from typing import List
+import heapq
+
+class Solution:
+    def minMeetingDays(self, intervals: List[tuple[int]]) -> int:
+        if not intervals:
+            return 0
+
+        # Sort intervals by start time (and by end time in case of a tie)
+        intervals.sort(key=lambda x: (x[0], x[1]))
+
+        # List to track the end times of meetings scheduled on each day
+        end_times = []
+
+        for interval in intervals:
+            placed = False
+            for i in range(len(end_times)):
+                if interval[0] >= end_times[i]:
+                    # If the meeting can be placed on this day
+                    end_times[i] = interval[1]
+                    placed = True
+                    break
+            if not placed:
+                # If it couldn't be placed on any existing day, schedule a new day
+                end_times.append(interval[1])
+
+        # The number of days required is the length of the end_times list
+        return len(end_times)
+
+
+    def minMeetingDays1(self, intervals):
+        if not intervals:
+            return 0
+
+        # 先按照開始時間排序，如果開始時間相同，則按結束時間排序
+        intervals.sort(key=lambda x: (x[0], x[1]))
+
+        # 使用最小堆來跟蹤每一天的最後一個會議的結束時間
+        min_heap = []
+
+        for interval in intervals:
+            if min_heap and interval[0] >= min_heap[0]:
+                # 如果當前會議的開始時間大於或等於最小堆頂的結束時間
+                # 更新最小堆頂的結束時間為當前會議的結束時間
+                heapq.heapreplace(min_heap, interval[1])
+            else:
+                # 無法放在任何已存在的天，需要新增加一天
+                heapq.heappush(min_heap, interval[1])
+
+        # 最小堆的大小就是所需的最少天數
+        return len(min_heap)
+    
+
+# Example usage
+solution = Solution()
+intervals1 = [(0, 40), (5, 10), (15, 20)]
+intervals2 = [(4, 9)]
+print(solution.minMeetingDays(intervals1))  # Output: 2
+print(solution.minMeetingDays(intervals2))  # Output: 1


### PR DESCRIPTION
To solve the problem of finding the minimum number of days required to schedule all meetings without any conflicts, we can leverage a greedy algorithm approach along with sorting. Here's the step-by-step approach:

1. Sort the Intervals: First, sort the intervals based on their start times. If two intervals have the same start time, then sort them by their end times.
2. Greedy Assignment: Use a list (or a priority queue) to keep track of the end times of the meetings scheduled on each day. Try to place each meeting in the earliest possible day without causing a conflict.
3. Conflict Check: For each meeting, check if it can be placed in any of the existing days (i.e., if its start time is after the end time of the last meeting on that day). If it can, update the end time of the last meeting on that day. If it can't be placed in any existing day, schedule it on a new day.

在這裡，「keep track of the end times」的意思是維護每一天安排的最後一個會議的結束時間，以便在安排新會議時，能夠快速確定該會議是否可以放在某一天而不產生衝突。

為了達到這個目的，我們使用一個最小堆（min-heap），它能有效地幫助我們追蹤和管理這些結束時間。最小堆允許我們快速獲取當前最早的結束時間，這對於判斷新會議能否放在已安排的某一天非常有用。

如何使用最小堆來跟蹤結束時間
1. 初始化最小堆：一開始最小堆是空的。
2. 遍歷會議區間：
- 如果當前會議的開始時間大於或等於最小堆頂部的結束時間，這意味著最小堆頂部對應的那一天已經可以放下這個新的會議，更新堆頂的結束時間為新會議的結束時間。
- 如果當前會議不能放在任何已有的天，則需要為這個會議新增一天，將它的結束時間加入到最小堆中。
3. 最終結果：最小堆的大小就是需要的最少天數。