### PR TITLE
CLI-77-Hand-of-Straights

### DIFF
--- a/21. Greedy/leetcode134.py
+++ b/21. Greedy/leetcode134.py
@@ -72,13 +72,33 @@ class Solution:
             return start
         else:
             return -1
+        
+    def BrouteForce(self, gas, cost):
+        n = len(gas)
+        
+        # 检查从每个站点出发是否可以完成环路
+        for start in range(n):
+            tank = 0
+            success = True
+            for i in range(n):
+                j = (start + i) % n  # 环路中的当前站点索引
+                tank += gas[j] - cost[j]
+                if tank < 0:
+                    success = False
+                    break
+            if success:
+                return start
+        
+        return -1  # 如果没有任何一个站点可以完成环路，则返回 -1
 
 # Example usage:
 sol = Solution()
 gas = [1, 2, 3, 4, 5]
 cost = [3, 4, 5, 1, 2]
 print(sol.canCompleteCircuit(gas, cost))  # Output: 3
+print(sol.BrouteForce(gas, cost))  # Output: 3
 
 gas = [2, 3, 4]
 cost = [3, 4, 3]
 print(sol.canCompleteCircuit(gas, cost))  # Output: -1
+print(sol.BrouteForce(gas, cost))  # Output: 3

--- a/21. Greedy/leetcode846.py
+++ b/21. Greedy/leetcode846.py
@@ -1,0 +1,60 @@
+'''
+846. Hand of Straights
+Medium
+
+Topics
+Companies
+Alice has some number of cards and she wants to rearrange the cards into
+groups so that each group is of size groupSize, and consists of groupSize
+consecutive cards.
+
+Given an integer array hand where hand[i] is the value written on the ith card
+and an integer groupSize, return true if she can rearrange the cards, or false
+otherwise.
+
+Example 1:
+Input: hand = [1,2,3,6,2,3,4,7,8], groupSize = 3
+Output: true
+Explanation: Alice's hand can be rearranged as [1,2,3],[2,3,4],[6,7,8]
+
+Example 2:
+Input: hand = [1,2,3,4,5], groupSize = 4
+Output: false
+Explanation: Alice's hand can not be rearranged into groups of 4.
+
+ 
+Constraints:
+1 <= hand.length <= 104
+0 <= hand[i] <= 109
+1 <= groupSize <= hand.length
+'''
+from collections import Counter
+
+class Solution:
+    def isNStraightHand(self, hand, groupSize):
+        if len(hand) % groupSize != 0:
+            return False
+        
+        count = Counter(hand)
+        
+        while count:
+            min_val = min(count)
+            for i in range(min_val, min_val + groupSize):
+                if count[i] == 0:
+                    return False
+                count[i] -= 1
+                if count[i] == 0:
+                    del count[i]
+        
+        return True
+
+# Example usage:
+solution = Solution()
+
+hand1 = [1, 2, 3, 6, 2, 3, 4, 7, 8]
+groupSize1 = 3
+print(solution.isNStraightHand(hand1, groupSize1))  # Output: True
+
+hand2 = [1, 2, 3, 4, 5]
+groupSize2 = 4
+print(solution.isNStraightHand(hand2, groupSize2))  # Output: False


### PR DESCRIPTION
1. 計數頻率：我們使用 Counter 從 collections 來計數每張牌出現的次數。
2. 早期退出：如果手牌的總數不能被 groupSize 整除，那麼無法形成所需的組，因此直接返回 False。
3. 形成組：
- 我們選擇最小的牌（因為連續組必須從最小的可用牌開始）。
- 對於從最小牌到最小牌加 groupSize 范圍內的每張牌，我們檢查該牌是否在 count 字典中。
- 如果所需范圍內的任何牌缺失，返回 False。
- 否則，減少每張用於組成該組的牌的計數。
- 清理：當牌的計數減少到零時，從字典中刪除該牌以避免不必要的迭代。